### PR TITLE
include mechanism for processing unfinished work from previous jobs

### DIFF
--- a/docker/ibldatajoint/docker-compose.yml
+++ b/docker/ibldatajoint/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       - populate
       - behavior
       - --duration=-1
-      - --sleep=10
+      - --sleep=1800
       - --backtrack=10
     container_name: populate_behavior
 

--- a/docker/ibldatajoint/docker-compose.yml
+++ b/docker/ibldatajoint/docker-compose.yml
@@ -135,7 +135,7 @@ services:
       - --alyxhost=dev
       - populate
       - ingest
-      - --duration=1
+      - --duration=-1
       - --backtrack=3
     scale: ${WORKER_COUNT:-1}
 
@@ -146,7 +146,7 @@ services:
       - --alyxhost=dev
       - populate
       - behavior
-      - --duration=1
+      - --duration=-1
       - --sleep=10
       - --backtrack=10
     container_name: populate_behavior

--- a/ibl_pipeline/acquisition_shared.py
+++ b/ibl_pipeline/acquisition_shared.py
@@ -56,26 +56,15 @@ class Session(dj.Manual):
                 # If this session is already in AlyxRaw, skip, as it will get inserted into Session in this ingestion cycle
                 continue
 
-            # Insert into AlyxRaw with incomplete info
-            # so it can be updated in the next daily ingestion cycle
-
-            sess = {**sess_key,
-                    'session_uuid': uuid.UUID(sess_uuid),
-                    'session_number': alyx_session['number'],
-                    'session_end_time': None,
-                    'session_lab': alyx_session['lab'],
-                    'session_location': None,
-                    'task_protocol': alyx_session['task_protocol'],
-                    'session_type': None,
-                    'session_narrative': None}
-
-            with cls.connection.transaction:
-                alyxraw.AlyxRaw.insert1({'uuid': uuid.UUID(sess_uuid), 'model': 'actions.session'})
-                alyxraw.AlyxRaw.Field.insert1({'uuid': uuid.UUID(sess_uuid),
-                                               'fname': 'end_time',
-                                               'value_idx': 0,
-                                               'fvalue': ''})
-                cls.insert1(sess)
+            cls.insert1({**sess_key,
+                         'session_uuid': uuid.UUID(sess_uuid),
+                         'session_number': alyx_session['number'],
+                         'session_end_time': None,
+                         'session_lab': alyx_session['lab'],
+                         'session_location': None,
+                         'task_protocol': alyx_session['task_protocol'],
+                         'session_type': None,
+                         'session_narrative': None})
 
 
 @schema

--- a/ibl_pipeline/acquisition_shared.py
+++ b/ibl_pipeline/acquisition_shared.py
@@ -1,6 +1,13 @@
 import datajoint as dj
+import datetime
+from tqdm import tqdm
+import uuid
+
 from . import reference, subject, action
-from . import mode
+from . import mode, one
+
+
+alyxraw = dj.create_virtual_module('alyxraw', dj.config.get('database.prefix', '') + 'ibl_alyxraw')
 
 
 # Map to the correct schema based on mode.
@@ -26,6 +33,62 @@ class Session(dj.Manual):
     session_narrative=null:     varchar(2048)
     session_ts=CURRENT_TIMESTAMP:   timestamp
     """
+
+    @classmethod
+    def insert_with_alyx_rest(cls, backtrack_days=1):
+        """Helper function that inserts new sessions by query alyx with rest api
+        Args:
+            backtrack_days (int): the number of days back to search for new sessions
+        """
+        date_cutoff = datetime.datetime.now() - datetime.timedelta(days=backtrack_days)
+
+        alyx_sessions = one.alyx.rest('sessions', 'list', django=f'start_time__gte,{date_cutoff}')
+
+        for alyx_session in tqdm(alyx_sessions):
+            sess_key = {
+                'subject_uuid': (subject.Subject & {'subject_nickname': alyx_session['subject']}).fetch1('subject_uuid'),
+                'session_start_time': datetime.datetime.strptime(alyx_session["start_time"], '%Y-%m-%dT%H:%M:%S.%f'),
+                }
+
+            if not cls & sess_key:
+                continue
+
+            sess_uuid = alyx_session['url'].split('/')[-1]
+
+            sess = {**sess_key,
+                    'session_uuid': uuid.UUID(sess_uuid),
+                    'session_number': alyx_session['number'],
+                    'session_end_time': None,
+                    'session_lab': alyx_session['lab'],
+                    'session_location': None,
+                    'task_protocol': alyx_session['task_protocol'],
+                    'session_type': None,
+                    'session_narrative': None}
+
+            if alyxraw.AlyxRaw & {'uuid': sess_uuid}:
+                # If this session is already in AlyxRaw, retrieve some additional information and insert
+                fnames, fvalues = (alyxraw.AlyxRaw.Field & {'uuid': sess_uuid}
+                                   & 'fname in ("end_time", "type", "narrative", "location")').fetch('fname', 'fvalue')
+                additional_info = {k: v for k, v in zip(fnames, fvalues)}
+
+                if additional_info.get('end_time'):
+                    sess['session_end_time'] = datetime.datetime.strptime(additional_info["end_time"], '%Y-%m-%d %H:%M:%S.%f')
+                sess['session_narrative'] = additional_info.get('narrative')
+                sess['session_type'] = additional_info.get('type')
+                if additional_info.get('location'):
+                    sess['session_location'] = (alyxraw.AlyxRaw.Field
+                                                & {'uuid': additional_info['location'], 'fname': 'name'}).fetch1('fvalue')
+                cls.insert1({**sess_key, **sess})
+            else:
+                # If this session is not yet in AlyxRaw, insert into AlyxRaw with incomplete info
+                # so it can be updated in the next daily ingestion cycle
+                with cls.connection.transaction:
+                    alyxraw.AlyxRaw.insert1({'uuid': uuid.UUID(sess_uuid), 'model': 'actions.session'})
+                    alyxraw.AlyxRaw.Field.insert1({'uuid': uuid.UUID(sess_uuid),
+                                                   'fname': 'end_time',
+                                                   'value_idx': 0,
+                                                   'fvalue': ''})
+                    cls.insert1({**sess_key, **sess})
 
 
 @schema

--- a/ibl_pipeline/analyses/behavior.py
+++ b/ibl_pipeline/analyses/behavior.py
@@ -707,6 +707,7 @@ class SessionTrainingStatus(dj.Computed):
         # if has reached 'trained_1a' before, mark the current session 'trained_1a' as well
         if len(status) and np.any(status == 'trained_1a'):
             key['training_status'] = 'trained_1a'
+            # TODO: check also for `trained_1a_4sess`
             self.insert1(key)
             return
 

--- a/ibl_pipeline/behavior_shared.py
+++ b/ibl_pipeline/behavior_shared.py
@@ -199,7 +199,7 @@ class CompleteTrialSession(dj.Computed):
             self.insert1(key)
         else:
             IncompleteTrialSession.insert1({**key, 'reason': 'missing required files'})
-            IncompleteTrialSession.insert({**key, 'missing_file': f} for f in missing_files)
+            IncompleteTrialSession.insert([{**key, 'missing_file': f} for f in missing_files])
 
 
 @schema

--- a/ibl_pipeline/behavior_shared.py
+++ b/ibl_pipeline/behavior_shared.py
@@ -74,6 +74,21 @@ class Wheel(dj.Imported):
 
 
 @schema
+class IncompleteTrialSession(dj.Computed):
+    definition = """
+    -> acquisition.Session
+    ---
+    reason: varchar(1000)
+    """
+
+    class MissingFile(dj.Part):
+        definition = """
+        -> master
+        missing_file: varchar(128)
+        """
+
+
+@schema
 class CompleteTrialSession(dj.Computed):
     definition = """
     # sessions that are complete with trial information and thus may be ingested
@@ -116,6 +131,11 @@ class CompleteTrialSession(dj.Computed):
 
     def make(self, key):
         datasets, missing_files = self.get_missing_files(key)
+
+        if key in IncompleteTrialSession:
+            with dj.config(safemode=False):
+                (IncompleteTrialSession & key).delete()
+
         if not missing_files:
             if '_ibl_trials.stimOn_times.npy' not in datasets:
                 key['stim_on_times_status'] = 'Missing'
@@ -177,6 +197,9 @@ class CompleteTrialSession(dj.Computed):
                 key['iti_duration_status'] = 'Complete'
 
             self.insert1(key)
+        else:
+            IncompleteTrialSession.insert1({**key, 'reason': 'missing required files'})
+            IncompleteTrialSession.insert({**key, 'missing_file': f} for f in missing_files)
 
 
 @schema

--- a/ibl_pipeline/ingest/job.py
+++ b/ibl_pipeline/ingest/job.py
@@ -776,8 +776,8 @@ class PopulateShadowTable(dj.Computed):
     definition = """
     -> ShadowTable
     ---
-    incomplete_count=null: int  # how many to be populated
-    completion_count=null: int  # how many has been populated
+    incomplete_count=null: int  # how many to be populated before this job
+    completion_count=null: int  # how many has been populated by this job
     """
 
     key_source = ShadowTable * IngestionJob & 'job_status = "on-going"'

--- a/ibl_pipeline/ingest/job.py
+++ b/ibl_pipeline/ingest/job.py
@@ -871,9 +871,7 @@ class CopyRealTable(dj.Computed):
                                        for s in tbl_name.strip('`').split('__') if s])
                      for schema_name, tbl_name in ancestors]
 
-        ancestors = [n for n in ancestors if n in self._real_tables
-                     and n in (self.key_source - self).fetch('table_name')
-                     and n != key['table_name']]
+        ancestors = [n for n in ancestors if n in self._real_tables and n != key['table_name']]
 
         are_ancestors_copied = (len(self & (IngestionJob & key)
                                     & [{'table_name': n} for n in ancestors])

--- a/ibl_pipeline/ingest/job.py
+++ b/ibl_pipeline/ingest/job.py
@@ -851,6 +851,8 @@ class PopulateShadowTable(dj.Computed):
 class CopyRealTable(dj.Computed):
     definition = """
     -> PopulateShadowTable
+    ---
+    transferred_count=null: int
     """
 
     _real_tables = [table_name for table_name, v in DJ_TABLES.items() if v['real'] is not None]
@@ -884,9 +886,9 @@ class CopyRealTable(dj.Computed):
         target_module = inspect.getmodule(real_table)
         source_module = inspect.getmodule(shadow_table)
 
-        ingest_real.copy_table(target_module, source_module, real_table.__name__)
+        transferred_count = ingest_real.copy_table(target_module, source_module, real_table.__name__)
 
-        self.insert1(key)
+        self.insert1({**key, 'transferred_count': transferred_count})
 
 
 @schema

--- a/ibl_pipeline/ingest/job.py
+++ b/ibl_pipeline/ingest/job.py
@@ -895,7 +895,7 @@ class UpdateRealTable(dj.Computed):
         modified_uuids = (AlyxRawDiff.ModifiedEntry & key
                           & {'alyx_model_name': alyx_model_name}).fetch('uuid')
 
-        uuid_attr = next((attr for attr in real_table.heading.names
+        uuid_attr = next((attr for attr in shadow_table.heading.names
                           if attr.endswith('uuid')))
 
         query = real_table & [{uuid_attr: u} for u in modified_uuids]

--- a/ibl_pipeline/ingest/job.py
+++ b/ibl_pipeline/ingest/job.py
@@ -871,7 +871,9 @@ class CopyRealTable(dj.Computed):
                                        for s in tbl_name.strip('`').split('__') if s])
                      for schema_name, tbl_name in ancestors]
 
-        ancestors = [n for n in ancestors if n in self._real_tables and n != key['table_name']]
+        ancestors = [n for n in ancestors if n in self._real_tables
+                     and n in (self.key_source - self).fetch('table_name')
+                     and n != key['table_name']]
 
         are_ancestors_copied = (len(self & (IngestionJob & key)
                                     & [{'table_name': n} for n in ancestors])

--- a/ibl_pipeline/ingest/job.py
+++ b/ibl_pipeline/ingest/job.py
@@ -848,6 +848,7 @@ class CopyRealTable(dj.Computed):
         real_table = DJ_TABLES[key['table_name']]['real']
 
         # Ensure the real-table copy routine is "in topologically sorted order"
+        # so, if ancestors of this table is not yet copied, exit and retry later
         schema_prefix = dj.config.get('database.prefix', '') + 'ibl_'
         ancestors = [tbl_name.split('.') for tbl_name in real_table.ancestors()]
         ancestors = [schema_name.strip('`').replace(schema_prefix, '')

--- a/ibl_pipeline/ingest/subject.py
+++ b/ibl_pipeline/ingest/subject.py
@@ -2,7 +2,7 @@ import datajoint as dj
 import json
 import uuid
 
-from . import alyxraw, reference
+from . import alyxraw, reference, ShadowIngestionError
 from . import get_raw_field as grf
 
 schema = dj.schema(dj.config.get('database.prefix', '') +
@@ -289,6 +289,9 @@ class SubjectCullMethod(dj.Computed):
         subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_c = key.copy()
         key['uuid'] = key['subject_uuid']
         self.insert1(dict(
@@ -412,6 +415,9 @@ class LitterSubject(dj.Computed):
         subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_ls = key.copy()
         key['uuid'] = key['subject_uuid']
         litter = grf(key, 'litter')
@@ -436,6 +442,9 @@ class SubjectProject(dj.Computed):
         subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_s = key.copy()
         key['uuid'] = key['subject_uuid']
 
@@ -468,6 +477,9 @@ class SubjectUser(dj.Computed):
         subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_su = key.copy()
         key['uuid'] = key['subject_uuid']
 
@@ -488,6 +500,9 @@ class SubjectLab(dj.Computed):
     """
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_sl = key.copy()
         key['uuid'] = key['subject_uuid']
         lab = grf(key, 'lab')
@@ -511,6 +526,9 @@ class Caging(dj.Computed):
     def make(self, key):
         key_cage = key.copy()
         key['uuid'] = key['subject_uuid']
+
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
 
         key_cage['cage_name'] = grf(key, 'cage')
         json_content = grf(key, 'json')
@@ -548,6 +566,9 @@ class UserHistory(dj.Computed):
     key_source = subjects.proj(subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_user = key.copy()
         key['uuid'] = key['subject_uuid']
 
@@ -595,6 +616,9 @@ class Weaning(dj.Computed):
         subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_weaning = key.copy()
         key['uuid'] = key['subject_uuid']
 
@@ -616,6 +640,9 @@ class Death(dj.Computed):
         subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_death = key.copy()
         key['uuid'] = key['subject_uuid']
         key_death['death_date'] = grf(key, 'death_date')
@@ -879,6 +906,9 @@ class Implant(dj.Computed):
         subject_uuid='uuid')
 
     def make(self, key):
+        if not len(Subject & key):
+            raise ShadowIngestionError(f'Subject not found in the table subject.Subject: {key["subject_uuid"]}')
+
         key_implant = key.copy()
         key['uuid'] = key['subject_uuid']
 

--- a/ibl_pipeline/process/ingest_real.py
+++ b/ibl_pipeline/process/ingest_real.py
@@ -165,6 +165,8 @@ def copy_table(target_schema, src_schema, table_name,
                   'ignore_extra_fields': True,
                   'allow_direct_insert': True}
 
+        transferred_count = len(q_insert)
+
         try:
             target_table.insert(q_insert, **kwargs)
         except Exception:
@@ -172,8 +174,11 @@ def copy_table(target_schema, src_schema, table_name,
                 try:
                     target_table.insert(q_insert & key, **kwargs)
                 except Exception:
+                    transferred_count -= 1
                     print("Error when inserting {}".format((q_insert & key).fetch1()))
                     traceback.print_exc()
+
+        return transferred_count
 
 
 def main(excluded_tables=[]):

--- a/ibl_pipeline/process/populate_behavior.py
+++ b/ibl_pipeline/process/populate_behavior.py
@@ -51,9 +51,11 @@ def main(backtrack_days=30, excluded_tables=None, run_duration=3600*3, sleep_dur
            or (run_duration is None)
            or (run_duration < 0)):
 
-        if backtrack_days:
-            date_cutoff = (datetime.datetime.now().date() -
-                           datetime.timedelta(days=backtrack_days)).strftime('%Y-%m-%d')
+        # Try inserting new sessions from querying directly the live alyx db
+        acquisition.Session.insert_with_alyx_rest(backtrack_days=1)
+
+        date_cutoff = (datetime.datetime.now().date() -
+                       datetime.timedelta(days=backtrack_days)).strftime('%Y-%m-%d')
 
         # ingest those dataset and file records where exists=False when json gets dumped
         # only check those sessions where required datasets are missing.

--- a/scripts/validate_new_ingestion.py
+++ b/scripts/validate_new_ingestion.py
@@ -1,0 +1,40 @@
+import datajoint as dj
+
+from ibl_pipeline import (reference, subject, action,
+                          acquisition, data, ephys, qc, histology)
+
+from ibl_pipeline.ingest import reference as shadow_reference
+from ibl_pipeline.ingest import subject as shadow_subject
+from ibl_pipeline.ingest import action as shadow_action
+from ibl_pipeline.ingest import acquisition as shadow_acquisition
+from ibl_pipeline.ingest import data as shadow_data
+from ibl_pipeline.ingest import ephys as shadow_ephys
+from ibl_pipeline.ingest import qc as shadow_qc
+from ibl_pipeline.ingest import histology as shadow_histology
+
+from ibl_pipeline.ingest import job
+
+
+real_vmods = {}
+for m in (reference, subject, action,
+          acquisition, data, ephys, qc, histology):
+    assert m.schema.database.startswith('test_')
+    schema_name = m.__name__.split('.')[-1]
+    real_vmods[schema_name] = dj.create_virtual_module(schema_name, m.schema.database[5:])
+
+session_res = 'session_start_time BETWEEN "2022-01-20" AND "2022-01-22"'
+session_keys = (real_vmods['acquisition'].Session & session_res).fetch('KEY')
+
+for full_table_name, table_detail in job.DJ_TABLES.items():
+    real_table = table_detail['real']
+    if real_table is None:
+        continue
+
+    print(f'Inspecting: {full_table_name} - ', end='')
+
+    schema_name, table_name = full_table_name.split('.')
+    vm_real_table = getattr(real_vmods[schema_name], table_name)
+
+    missing = (vm_real_table & session_keys) - (real_table & session_keys).proj()
+
+    print(f'missing {len(missing)}')


### PR DESCRIPTION
+ Bugfix in retrieving the correct uuid attribute name 
+ Include mechanism for processing unfinished work from previous jobs
+ Check and ingest latest sessions by querying directly the live Alyx DB

There was a logic flaw in the ingestion logic. In short, the daily ingestion follows the steps:
1. From sqldump, load from alyx db into DJ table `UpdateAlyxRaw` (this represent the latest state of the Alyx DB)
2. Compare between `UpdateAlyxRaw` vs. `AlyxRaw`, find newly created, or deleted, or modified entries
3. Delete those "deleted" or "modified" entries from `AlyxRaw`, and corresponding shadow tables
4. Copy from `UpdateAlyxRaw` to `AlyxRaw` (now, `AlyxRaw` should also have the latest state of the Alyx DB)
5. Populate the shadow tables with the latest `AlyxRaw`
6. From shadow tables, copy new entries or update existing entries in the real table accordingly

Now, if for some reason the ingestion crashes at step 4, so step 5 and 6 are never finished, coupled with the cases where the next job happens to be on a new sql dump. In such cases, the ingestion never made it to the import step of making changes to the real table. And on the next job, `UpdateAlyxRaw` will show no differences compared to `AlyxRaw`, so no new fixes will be triggered for this new job, and the needed fixes from the old job is now abandoned, not tracked/reflected anywhere.

The changes in this PR aim to fix this logic flaw

