### PR TITLE
add scripts for data publishing - Feb 2022

### DIFF
--- a/ibl_pipeline/behavior_shared.py
+++ b/ibl_pipeline/behavior_shared.py
@@ -480,7 +480,7 @@ class Tag(dj.Lookup):
 @schema
 class SessionTag(dj.Computed):
     definition = """
-    -> Session
+    -> acquisition.Session
     """
 
     class Tag(dj.Part):

--- a/scripts/data_publishing_Feb2022/__init__.py
+++ b/scripts/data_publishing_Feb2022/__init__.py
@@ -1,3 +1,6 @@
+# Requites datajoint_utilities
+# pip install git+https://github.com/vathes/datajoint-utilities.git
+
 import datajoint as dj
 
 assert 'custom' in dj.config

--- a/scripts/data_publishing_Feb2022/__init__.py
+++ b/scripts/data_publishing_Feb2022/__init__.py
@@ -1,0 +1,22 @@
+import datajoint as dj
+
+assert 'custom' in dj.config
+
+assert 'target_database.host' in dj.config['custom']
+assert 'target_database.user' in dj.config['custom']
+assert 'target_database.password' in dj.config['custom']
+assert 'target_database.db_prefix' in dj.config['custom']
+
+source_db_prefix = dj.config['database.prefix']
+target_db_prefix = dj.config['custom']['target_database.db_prefix']
+
+schema_name_mapper = {source_db_prefix + schema_name: target_db_prefix + schema_name
+                      for schema_name in ('ibl_reference',
+                                          'ibl_subject',
+                                          'ibl_action',
+                                          'ibl_data',
+                                          'ibl_acquisition',
+                                          'ibl_behavior',
+                                          'ibl_analyses_behavior',
+                                          'ibl_ephys',
+                                          'ibl_histology')}

--- a/scripts/data_publishing_Feb2022/clone_internal_ibl.py
+++ b/scripts/data_publishing_Feb2022/clone_internal_ibl.py
@@ -1,0 +1,15 @@
+import datajoint as dj
+from datajoint_utilities.dj_data_copy.pipeline_cloning import ClonedPipeline
+
+from . import schema_name_mapper, source_db_prefix
+
+
+def clone_ibl_pipeline():
+    ibl_behavior = dj.create_virtual_module('ibl_behavior', source_db_prefix + 'ibl_behavior')
+    ibl_ephys = dj.create_virtual_module('ibl_ephys', source_db_prefix + 'ibl_ephys')
+
+    diagram = dj.Diagram(ibl_behavior.CompleteTrialSession) + dj.Diagram(ibl_ephys.AlignedTrialSpikes)
+
+    cloned_pipeline = ClonedPipeline(diagram, schema_name_mapper, verbose=True)
+
+    cloned_pipeline.save_code(save_dir=f'./cloned_pipelines/{target_db_prefix}')

--- a/scripts/data_publishing_Feb2022/clone_public_ibl.py
+++ b/scripts/data_publishing_Feb2022/clone_public_ibl.py
@@ -1,0 +1,32 @@
+import datajoint as dj
+from datajoint_utilities.dj_data_copy.pipeline_cloning import ClonedPipeline
+
+from . import schema_name_mapper, source_db_prefix, target_db_prefix
+
+
+def clone_public_ibl_pipeline():
+    ibl_acquisition = dj.create_virtual_module('ibl_acquisition', source_db_prefix + 'ibl_acquisition')
+    ibl_action = dj.create_virtual_module('ibl_action', source_db_prefix + 'ibl_action')
+    ibl_analyses_behavior = dj.create_virtual_module('ibl_analyses_behavior', source_db_prefix + 'ibl_analyses_behavior')
+    ibl_behavior = dj.create_virtual_module('ibl_behavior', source_db_prefix + 'ibl_behavior')
+    ibl_data = dj.create_virtual_module('ibl_data', source_db_prefix + 'ibl_data')
+    ibl_ephys = dj.create_virtual_module('ibl_ephys', source_db_prefix + 'ibl_ephys')
+    ibl_subject = dj.create_virtual_module('ibl_subject', source_db_prefix + 'ibl_subject')
+    ibl_histology = dj.create_virtual_module('ibl_histology', source_db_prefix + 'ibl_histology')
+    ibl_reference = dj.create_virtual_module('ibl_reference', source_db_prefix + 'ibl_reference')
+
+    diagram = (
+        dj.Diagram(ibl_acquisition)
+        + dj.Diagram(ibl_action)
+        + dj.Diagram(ibl_analyses_behavior)
+        + dj.Diagram(ibl_behavior)
+        + dj.Diagram(ibl_data)
+        + dj.Diagram(ibl_ephys)
+        + dj.Diagram(ibl_subject)
+        + dj.Diagram(ibl_histology)
+        + dj.Diagram(ibl_reference)
+    )
+
+    cloned_pipeline = ClonedPipeline(diagram, schema_name_mapper, verbose=True)
+
+    cloned_pipeline.save_code(save_dir=f'./cloned_pipelines/{target_db_prefix}')

--- a/scripts/data_publishing_Feb2022/data_copy_ibl.py
+++ b/scripts/data_publishing_Feb2022/data_copy_ibl.py
@@ -1,0 +1,38 @@
+import datajoint as dj
+from datajoint_utilities.dj_data_copy import db_migration
+
+from . import schema_name_mapper
+
+# ------------ DATA COPY -------------
+
+# Set up connection credentials and store config
+source_conn = dj.connection.Connection(dj.config['database.host'],
+                                       dj.config['database.user'],
+                                       dj.config['database.password'])
+target_conn = dj.connection.Connection(dj.config['custom']['target_database.host'],
+                                       dj.config['custom']['target_database.user'],
+                                       dj.config['custom']['target_database.password'])
+
+# Data copy
+
+ibl_acquisition = dj.create_virtual_module('ibl_acquisition', 'ibl_acquisition', connection=source_conn)
+ibl_ephys = dj.create_virtual_module('ibl_ephys', 'ibl_ephys', connection=source_conn)
+
+sessions = (ibl_acquisition.Session & ibl_ephys.DefaultCluster).fetch('KEY', limit=10)
+
+table_block_list = {}
+
+batch_size = None
+
+
+def main():
+    for orig_schema_name, cloned_schema_name in schema_name_mapper.items():
+        orig_schema = dj.create_virtual_module(orig_schema_name, orig_schema_name, connection=source_conn)
+        cloned_schema = dj.create_virtual_module(cloned_schema_name, cloned_schema_name, connection=target_conn)
+
+        db_migration.migrate_schema(orig_schema, cloned_schema,
+                                    restriction=sessions,
+                                    table_block_list=table_block_list.get(cloned_schema_name, []),
+                                    allow_missing_destination_tables=True,
+                                    force_fetch=False,
+                                    batch_size=batch_size)


### PR DESCRIPTION
Prototype set of script for pipeline cloning and data transfer from the internal to the public IBL pipeline. The scaffold is there, further configuration needed.

Do we need to publish new tables? If not, only the `data_copy_ibl.py` is needed.